### PR TITLE
Add initial server docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /code
+WORKDIR /code
+COPY requirements.txt /code/
+RUN pip install -r requirements.txt
+COPY . /code/

--- a/MidasWebsite/settings.py
+++ b/MidasWebsite/settings.py
@@ -28,7 +28,8 @@ ALLOWED_HOSTS = [
     'django-env.dsypxa5mag.us-west-2.elasticbeanstalk.com',
     'django-env.dsypxa5mag.us-west-2.elasticbeanstalk.com',
     '0.0.0.0',
-    'localhost'
+    'localhost',
+    'ec2-18-219-155-220.us-east-2.compute.amazonaws.com'
 ]
 
 # Application definition

--- a/MidasWebsite/settings.py
+++ b/MidasWebsite/settings.py
@@ -24,8 +24,12 @@ SECRET_KEY = 'wk8gx50yl09)ss^o=xy1bfg(hyr*_mq!#x=#b!!@=9hzc4b5&l'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['django-env.dsypxa5mag.us-west-2.elasticbeanstalk.com', 
-        'django-env.dsypxa5mag.us-west-2.elasticbeanstalk.com']
+ALLOWED_HOSTS = [
+    'django-env.dsypxa5mag.us-west-2.elasticbeanstalk.com',
+    'django-env.dsypxa5mag.us-west-2.elasticbeanstalk.com',
+    '0.0.0.0',
+    'localhost'
+]
 
 # Application definition
 INSTALLED_APPS = [
@@ -82,12 +86,15 @@ WSGI_APPLICATION = 'MidasWebsite.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.sqlite3',
-#         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-#     }
-# }
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'HOST': 'db',
+        'PORT': 5432
+    }
+}
 
 
 # Password validation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.4'
+
+services:
+  db:
+    image: postgres
+  web:
+    build: .
+    restart: always
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/code
+    ports:
+      - "80:8000"
+    depends_on:
+      - db

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==2.2.6
 django-crispy-forms==1.8.0
 pytz==2019.3
 sqlparse==0.3.0
+psycopg2>=2.7,<3.0


### PR DESCRIPTION
@jsturtz This is just a rough version and might need some tweaking for a live site, but it works for a local development server. This will create a webserver running on port 80 on the host machine, and a Postgresql database accessible by the webserver but not exposed on any ports on the host machine. If run on your own machine, you should be able to access the site by visiting `localhost` or `0.0.0.0` in a web browser.

To run on a given machine, you will need `git`, `docker`, and `docker-compose` installed.

Usage (within the project root):
```bash
docker-compose up
```
If you add any Python dependencies to `requirements.txt`, the image for the `web` service will need to be rebuilt:
```bash
docker-compose build
```

**Note**: There are a few things that aren't necessarily best practice/secure, such as the database not having a password, or directly using Django's webserver instead of forwarding traffic to it with something like Nginx or Apache. They can be added, but given that this is not a real production site with sensitive data/high load, I've foregone the overhead for now.

You should (hopefully) be able to install the aforementioned dependencies on an EC2 instance, clone the repo, and the execute the above commands. You may need to tell AWS to allow traffic to port 80 for that instance (since I think only port 22 is open by default for SSH access).

One last thing: if you did want to run additional python processes (which you shouldn't need save for perhaps long-running training, but I am mentioning for completeness), you can simply add them as services in `docker-compose.yml` (and maybe make a Dockerfile for them too, depending on complexity).